### PR TITLE
Interpreter is now determined from config file

### DIFF
--- a/bin/aenv
+++ b/bin/aenv
@@ -16,17 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# handle module loading for cluster thinking
-case "${VSC_INSTITUTE_CLUSTER}" in
-    thinking)
-        PYTHON="/apps/leuven/common/python/2.7.9_sysadm/bin/python"
-        ;;
-    breniac)
-        module purge
-        module load Python/2.7.11-foss-2016a
-        ;;
-esac
-
 # ensure that OpenBLAS doesn't blow up
 export OMP_NUM_THREADS=1
 
@@ -39,6 +28,9 @@ then
     DIR=$( cd -P "$( dirname "${exec}" )" && pwd )
     export VSC_MODULE_DEPENDENCIES_DIR="${DIR}/.."
 fi
+
+# load the Python interpeter from the config file
+source "${DIR}/../conf/atools.conf"
 
 # add scripts and lib directory to PYTHONPATH
 if [ -z "${VSC_MODULE_DEPENDENCIES_SCRIPTS_DIR}" ]

--- a/bin/alog
+++ b/bin/alog
@@ -16,17 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# handle module loading for cluster thinking
-case "${VSC_INSTITUTE_CLUSTER}" in
-    thinking)
-        PYTHON="/apps/leuven/common/python/2.7.9_sysadm/bin/python"
-        ;;
-    breniac)
-        module purge
-        module load Python/2.7.11-foss-2016a
-        ;;
-esac
-
 # ensure that OpenBLAS doesn't blow up
 export OMP_NUM_THREADS=1
 
@@ -39,6 +28,9 @@ then
     DIR=$( cd -P "$( dirname "${exec}" )" && pwd )
     export VSC_MODULE_DEPENDENCIES_DIR="${DIR}/.."
 fi
+
+# load the Python interpeter from the config file
+source "${DIR}/../conf/atools.conf"
 
 # add scripts and lib directory to PYTHONPATH
 if [ -z "${VSC_MODULE_DEPENDENCIES_SCRIPTS_DIR}" ]

--- a/bin/arange
+++ b/bin/arange
@@ -16,17 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-# handle module loading for cluster thinking
-case "${VSC_INSTITUTE_CLUSTER}" in
-    thinking)
-        PYTHON="/apps/leuven/common/python/2.7.9_sysadm/bin/python"
-        ;;
-    breniac)
-        module purge
-        module load Python/2.7.11-foss-2016a
-        ;;
-esac
-
 # ensure that OpenBLAS doesn't blow up
 export OMP_NUM_THREADS=1
 
@@ -39,6 +28,9 @@ then
     DIR=$( cd -P "$( dirname "${exec}" )" && pwd )
     export VSC_MODULE_DEPENDENCIES_DIR="${DIR}/.."
 fi
+
+# load the Python interpeter from the config file
+source "${DIR}/../conf/atools.conf"
 
 # add scripts and lib directory to PYTHONPATH
 if [ -z "${VSC_MODULE_DEPENDENCIES_SCRIPTS_DIR}" ]

--- a/conf/atools.conf
+++ b/conf/atools.conf
@@ -1,0 +1,1 @@
+export PYTHON="/apps/leuven/common/python/2.7.9_sysadm/bin/python"

--- a/conf/breniac.conf
+++ b/conf/breniac.conf
@@ -1,0 +1,1 @@
+PYTHON=/apps/leuven/broadwell/2016a/software/Python/2.7.11-foss-2016a

--- a/conf/thinking.conf
+++ b/conf/thinking.conf
@@ -1,0 +1,1 @@
+export PYTHON="/apps/leuven/common/python/2.7.9_sysadm/bin/python"


### PR DESCRIPTION
The Python interpreter is now specified in a configuration file, rather than in each of the bash wrapper scripts.