### PR TITLE
Update config.md

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -15,7 +15,7 @@ batch_system = torque
 mode = text
 # default Linux shell
 shell = bash
-````
+```
 
 The supported batch systems are:
 


### PR DESCRIPTION
Remove extra backtick in code section. It breaks the rendering on https://atools.readthedocs.io/en/latest/config/