### PR TITLE
Fix missing enivonrment variable name definition

### DIFF
--- a/conf/atools.conf
+++ b/conf/atools.conf
@@ -13,21 +13,25 @@ shell = bash
 array_idx_var = PBS_ARRAYID
 job_id_var = PBS_JOBID
 job_name_var = PBS_JOBNAME
+submission_dir = PBS_O_WORKDIR
 
 [moab]
 array_idx_var = MOAB_JOBARRAYINDEX
 job_id_var = MOAB_JOBID
 job_name_var = MOAB_JOBNAME
+submission_dir = MOAB_SUBMITDIR
 
 [sge]
 array_idx_var = SGE_TASK_ID
 job_id_var = JOB_ID
 job_name_var = JOB_NAME
+submission_dir = SGE_O_WORKDIR
 
 [slurm]
 array_idx_var = SLURM_ARRAY_TASK_ID
 job_id_var = SLURM_ARRAY_JOB_ID
 job_name_var = SLURM_JOB_NAME
+submission_dir = SLURM_SUBMIT_DIR
 
 # file formats for reduction
 [text]

--- a/conf/atools.conf.m4
+++ b/conf/atools.conf.m4
@@ -13,21 +13,25 @@ shell = SHELL
 array_idx_var = PBS_ARRAYID
 job_id_var = PBS_JOBID
 job_name_var = PBS_JOBNAME
+submission_dir = PBS_O_WORKDIR
 
 [moab]
 array_idx_var = MOAB_JOBARRAYINDEX
 job_id_var = MOAB_JOBID
 job_name_var = MOAB_JOBNAME
+submission_dir = MOAB_SUBMITDIR
 
 [sge]
 array_idx_var = SGE_TASK_ID
 job_id_var = JOB_ID
 job_name_var = JOB_NAME
+submission_dir = SGE_O_WORKDIR
 
 [slurm]
 array_idx_var = SLURM_ARRAY_TASK_ID
 job_id_var = SLURM_ARRAY_JOB_ID
 job_name_var = SLURM_JOB_NAME
+submission_dir = SLURM_SUBMIT_DIR
 
 # file formats for reduction
 [text]

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([atools], [1.5.0], [geertjan.bex@uhasselt.be])
+AC_INIT([atools], [1.5.1], [geertjan.bex@uhasselt.be])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign tar-pax])
 
 AC_CONFIG_FILES([


### PR DESCRIPTION
Definitions of the names of the environment variables that hold the submission directory were missing from the configuration file.